### PR TITLE
fix: change api url

### DIFF
--- a/src/apiUrl.js
+++ b/src/apiUrl.js
@@ -1,4 +1,4 @@
-const SERVER_DOMAIN = 'http://13.209.89.169:9090/api';
+const SERVER_DOMAIN = 'http://almostthere.podo.world/api';
 
 export const getMembers = (uuid) => `${SERVER_DOMAIN}/members?uuid=${uuid}`;
 


### PR DESCRIPTION
- aws 서버 migration 하면서 url 변경 필요합니다. 
- 선작업으로 기존 서버 ip 주소를 바라보는 대신 새 프록시 서버의 domain 을 바라보게 변경합니다. 